### PR TITLE
fix MacOS compatibility issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ Makefile
 zeitgeist
 *.exe
 *.user.pro
+.qmake*
+*.app

--- a/src/gamewindow.cpp
+++ b/src/gamewindow.cpp
@@ -83,7 +83,7 @@ GameWindow::GameWindow(QWidget* parent, const DataManager* dataManager) :
   connect(this, SIGNAL(useGame(const QString&)),
           dataManager, SLOT(useGame(const QString&)));
     connect(closeWindowButton, SIGNAL(clicked()),
-	    this, SLOT(onClickClose()));
+	    this, SLOT(close()));
 
   QHBoxLayout* layout = new QHBoxLayout;
   layout->addWidget(gameList);
@@ -110,11 +110,6 @@ void GameWindow::remove()
     emit removeGame(index);
     gameList->resizeColumnsToContents();
   }
-}
-
-void GameWindow::onClickClose()
-{
-  this->close();
 }
 
 void GameWindow::select()

--- a/src/gamewindow.cpp
+++ b/src/gamewindow.cpp
@@ -82,8 +82,8 @@ GameWindow::GameWindow(QWidget* parent, const DataManager* dataManager) :
           this, SLOT(select()));
   connect(this, SIGNAL(useGame(const QString&)),
           dataManager, SLOT(useGame(const QString&)));
-    connect(closeWindowButton, SIGNAL(clicked()),
-	    this, SLOT(close()));
+  connect(closeWindowButton, SIGNAL(clicked()),
+	  this, SLOT(close()));
 
   QHBoxLayout* layout = new QHBoxLayout;
   layout->addWidget(gameList);

--- a/src/gamewindow.cpp
+++ b/src/gamewindow.cpp
@@ -61,11 +61,13 @@ GameWindow::GameWindow(QWidget* parent, const DataManager* dataManager) :
   addGameButton = new QPushButton(tr("Add"), this);
   removeGameButton = new QPushButton(tr("Remove"), this);
   selectGameButton = new QPushButton(tr("Select"), this);
+  closeWindowButton = new QPushButton(tr("Close"), this);
   QVBoxLayout* buttonLayout = new QVBoxLayout;
   buttonLayout->addStretch();
   buttonLayout->addWidget(addGameButton);
   buttonLayout->addWidget(removeGameButton);
   buttonLayout->addWidget(selectGameButton);
+  buttonLayout->addWidget(closeWindowButton);
   connect(addGameButton, SIGNAL(clicked()),
           this, SLOT(browse()));
   connect(this, SIGNAL(addGame(const QString&)),
@@ -80,6 +82,8 @@ GameWindow::GameWindow(QWidget* parent, const DataManager* dataManager) :
           this, SLOT(select()));
   connect(this, SIGNAL(useGame(const QString&)),
           dataManager, SLOT(useGame(const QString&)));
+    connect(closeWindowButton, SIGNAL(clicked()),
+	    this, SLOT(onClickClose()));
 
   QHBoxLayout* layout = new QHBoxLayout;
   layout->addWidget(gameList);
@@ -106,6 +110,11 @@ void GameWindow::remove()
     emit removeGame(index);
     gameList->resizeColumnsToContents();
   }
+}
+
+void GameWindow::onClickClose()
+{
+  this->close();
 }
 
 void GameWindow::select()

--- a/src/gamewindow.h
+++ b/src/gamewindow.h
@@ -21,6 +21,7 @@ private slots:
   void browse();
   void remove();
   void select();
+  void onClickClose();
   void select(const QModelIndex& index);
   void notAGameDirectory(const QString& path);
   void rowsInserted(const QModelIndex&, int start, int end);
@@ -33,6 +34,7 @@ signals:
 private:
   const DataManager* dataManager;
   QTableView* gameList;
+  QPushButton* closeWindowButton;
   QPushButton* addGameButton;
   QPushButton* removeGameButton;
   QPushButton* selectGameButton;

--- a/src/gamewindow.h
+++ b/src/gamewindow.h
@@ -21,7 +21,6 @@ private slots:
   void browse();
   void remove();
   void select();
-  void onClickClose();
   void select(const QModelIndex& index);
   void notAGameDirectory(const QString& path);
   void rowsInserted(const QModelIndex&, int start, int end);

--- a/src/queuedmodsmodel.cpp
+++ b/src/queuedmodsmodel.cpp
@@ -136,7 +136,11 @@ void QueuedModsModel::unqueue(const QModelIndexList& indices)
     foreach (int compIndex, compList) {
       removeRow(compIndex, parent);
     }
-    if (!parent.child(0, 0).isValid()) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
+    if (!parent.model()->hasIndex(0, 0, parent)) {
+#else
+    if (!parent.child(0, 0)) {
+#endif
       removeRow(modIndex);
     }
   }

--- a/src/queuedmodsmodel.cpp
+++ b/src/queuedmodsmodel.cpp
@@ -139,7 +139,7 @@ void QueuedModsModel::unqueue(const QModelIndexList& indices)
 #if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
     if (!parent.model()->hasIndex(0, 0, parent)) {
 #else
-    if (!parent.child(0, 0)) {
+    if (!parent.child(0, 0).isValid()) {
 #endif
       removeRow(modIndex);
     }

--- a/src/terminalwindow.cpp
+++ b/src/terminalwindow.cpp
@@ -48,10 +48,12 @@ TerminalWindow::TerminalWindow(QWidget* parent,
   inputLine = new QLineEdit(this);
 
   QPushButton* enterButton = new QPushButton(tr("Enter"), this);
+  QPushButton* closeButton = new QPushButton(tr("Close"), this);
 
   QHBoxLayout* inputLayout = new QHBoxLayout;
   inputLayout->addWidget(inputLine);
   inputLayout->addWidget(enterButton);
+  inputLayout->addWidget(closeButton);
 
   QVBoxLayout* mainLayout = new QVBoxLayout;
   mainLayout->addWidget(outputPane);
@@ -67,6 +69,8 @@ TerminalWindow::TerminalWindow(QWidget* parent,
           coordinator->controller, SIGNAL(processInput(const QString&)));
   connect(coordinator->controller, SIGNAL(installTaskEnded()),
           this, SLOT(installTaskEnded()));
+  connect(closeButton, SIGNAL(clicked()),
+          this, SLOT(close()));
 }
 
 TerminalWindow::~TerminalWindow()

--- a/src/weidumanager.cpp
+++ b/src/weidumanager.cpp
@@ -157,7 +157,7 @@ void WeiduManager::endTask(int exitCode, QProcess::ExitStatus exitStatus)
 {
   delete weiduLogLocker;
   weiduLogLocker = nullptr;
-  if (!exitCode == 0 || !exitStatus == 0) {
+  if (exitCode != 0 || exitStatus != 0) {
     qDebug() << "Abnormal return values from process";
     qDebug() << "Exit code:" << QString::number(exitCode) <<
       "Exit status:" << QString::number(exitStatus);

--- a/zeitgeist.pro
+++ b/zeitgeist.pro
@@ -4,14 +4,17 @@ TEMPLATE = app
 # QMake's debug/release build mechanics are complete BS. So, in order
 # to build a release build, you need to remove the debug option and
 # maybe add the release option (depending on the defaults of your Qt
-# distribution).
+x# distribution).
 
 CONFIG += debug
 QMAKE_CXXFLAGS += -std=c++11 -isystem $$[QT_INSTALL_HEADERS]
-
+mac {
+mac:INCLUDEPATH += /usr/local/include/quazip5
+mac:LIBS += -L/usr/local/lib -lquazip5
+} else {
 unix:INCLUDEPATH += /usr/include/quazip5 # Directory with header files
 unix:LIBS += -L/usr/lib64 -lquazip5 # -L<path/to> -l<library>
-
+}
 win32:INCLUDEPATH += C:\lib\include\quazip # Folder with header files
 win32:LIBS += -LC:\lib\bin -lquazip # -L<path/to> -l<library>
 
@@ -48,6 +51,10 @@ RCC_DIR = $$BUILD_DIR
 
 include(src.pri)
 
+mac {
+OUTPUT_FILE = $$quote($$DESTDIR/$$TARGET\.app)
+QMAKE_POST_LINK += $$QMAKE_COPY -R $$OUTPUT_FILE "."
+} else {
 unix:OUTPUT_FILE = $$quote($$DESTDIR/$$TARGET)
-
 unix:QMAKE_POST_LINK += $$QMAKE_COPY $$OUTPUT_FILE "."
+}

--- a/zeitgeist.pro
+++ b/zeitgeist.pro
@@ -4,7 +4,7 @@ TEMPLATE = app
 # QMake's debug/release build mechanics are complete BS. So, in order
 # to build a release build, you need to remove the debug option and
 # maybe add the release option (depending on the defaults of your Qt
-x# distribution).
+# distribution).
 
 CONFIG += debug
 QMAKE_CXXFLAGS += -std=c++11 -isystem $$[QT_INSTALL_HEADERS]


### PR DESCRIPTION
I've not found any other way to close widgets in OSX than adding a close button, so I did that. Might want to put them inside a preprocessor check to avoid duplicating functionality, just in case either other platforms or older versions of Qt work differently.

Everything else I hope is self-explanatory.